### PR TITLE
remove kometa's overlay label when uploading posters

### DIFF
--- a/DapsEX/plex_upload.py
+++ b/DapsEX/plex_upload.py
@@ -64,7 +64,19 @@ class PlexUploaderr:
                 try:
                     library = getattr(item, "librarySectionTitle", "Unknown Library")
                     edition = getattr(item, "editionTitle", None)
+                    # this is where we should remove the overlay label in plex that kometa added
+                    labels = getattr(item, "labels", None)
+                    hasKometaOverlayLabel = False
+                    if labels:
+                        for label in labels:
+                            if label.tag == 'Overlay':
+                                hasKometaOverlayLabel = True
+                                break
                     item.uploadPoster(filepath=file_path)
+                    # remove the label only after the poster upload
+                    # this will allow Kometa to pick it up on its next run
+                    if hasKometaOverlayLabel:
+                        item.removeLabel(['Overlay'])
                     libraries.add(library)
                     if edition:
                         editions.add(edition)


### PR DESCRIPTION
kometa relies on an `Overlay` label to tell it what it has previously processed.  If a poster changes outside of kometa itself it won't detect this and the previously applied overlays will be gone and never updated.  By removing the label, Kometa will detect this on its next run and reapply overlays as needed.

https://github.com/zarskie/daps-ui/issues/13