### PR TITLE
enable writing to rclone log file if DEBUG is enabled

### DIFF
--- a/DapsEX/drive_sync.py
+++ b/DapsEX/drive_sync.py
@@ -112,7 +112,6 @@ class DriveSync:
                 continue
 
             self.logger.info(f"Starting sync for: '{drive_name}' -> '{drive_location}'")
-
             rclone_command = [
                 "rclone",
                 "sync",
@@ -130,9 +129,12 @@ class DriveSync:
                 "--bwlimit=80M",
                 "--size-only",
                 "--delete-during",
-                # "--log-file=/config/rclone.log",
                 "-v",
             ]
+
+            if self.logger.isEnabledFor(logging.DEBUG):
+                rclone_command.append("--log-file=/config/rclone.log")
+
 
             # Initialize using OAuth
             if self.client_id and self.rclone_secret and self.rclone_token:

--- a/DapsEX/drive_sync.py
+++ b/DapsEX/drive_sync.py
@@ -87,6 +87,8 @@ class DriveSync:
         progress_step = 90 // total_drives if total_drives > 0 else 90
 
         # rotate the prior log file and also delete older log files
+        # could consider setting up something more official w/ logrotate perhaps?
+        # but this should suffice.
         rclone_log_dir = "/config/"
         rclone_log_file = "rclone.log"
         rclone_rotated_log_suffix = "1"


### PR DESCRIPTION
This will also do some basic rotation from within the code and only keep 1 historical file since these can get pretty big.  Might be worth considering a "proper" log rotation for this? but this does work for now.