### PR TITLE
bug: unmatched assets was assuming 2 digit years

### DIFF
--- a/DapsEX/unmatched_assets.py
+++ b/DapsEX/unmatched_assets.py
@@ -60,7 +60,7 @@ class UnmatchedAssets:
         is_collection_asset: bool | None = None,
     ) -> list | list[tuple[str, str]]:
         extracted_assets = []
-        season_pattern = r"Season\d{2}"
+        season_pattern = r"Season\d+"
         for asset_path, data in asset_dict.items():
             if data.get("media_type") != asset_type:
                 continue


### PR DESCRIPTION
Change this to allow any length of season numbers as long as conesecutive digits.  This aligns with poster_renamer, too.  Fixes #46 

NOTE: I couldn't verify this locally as I don't have media with year season numbers, but I did run unmatched assets and no existing things broke.  I also pulled the regex out manually and tested outside of the code and it did what we would expect.