### PR TITLE
remove webhook_run from being stored on data objects

### DIFF
--- a/DapsEX/plex_upload.py
+++ b/DapsEX/plex_upload.py
@@ -67,16 +67,16 @@ class PlexUploaderr:
                     edition = getattr(item, "editionTitle", None)
                     # this is where we should remove the overlay label in plex that kometa added
                     labels = getattr(item, "labels", None)
-                    hasKometaOverlayLabel = False
+                    has_kometa_overlay_label = False
                     if labels:
                         for label in labels:
                             if label.tag == "Overlay":
-                                hasKometaOverlayLabel = True
+                                has_kometa_overlay_label = True
                                 break
                     item.uploadPoster(filepath=file_path)
                     # remove the label only after the poster upload
                     # this will allow Kometa to pick it up on its next run
-                    if hasKometaOverlayLabel:
+                    if has_kometa_overlay_label:
                         item.removeLabel(["Overlay"])
                     libraries.add(library)
                     if edition:
@@ -512,7 +512,7 @@ class PlexUploaderr:
             )
         else:
             self.logger.info(
-                "Reapply posters is disabled. Leaving cached upload state in tact"
+                "Reapply posters is disabled. Leaving cached upload state intact"
             )
 
         cached_files = self.db.return_all_files()

--- a/DapsEX/poster_renamerr.py
+++ b/DapsEX/poster_renamerr.py
@@ -335,21 +335,13 @@ class PosterRenamerr:
         return source_files
 
     def handle_movie_match(
-        self,
-        matched_movies,
-        file,
-        movie_data,
-        movie_has_file,
-        movie_status,
-        webhook_run,
+        self, matched_movies, file, movie_data, movie_has_file, movie_status
     ):
         matched_movies[file] = {
             "has_file": movie_has_file,
             "status": movie_status,
             "match": movie_data,
         }
-        if webhook_run:
-            matched_movies[file]["webhook_run"] = webhook_run
 
     def is_season_complete(self, show_seasons, show_data):
         return (
@@ -359,15 +351,13 @@ class PosterRenamerr:
         )
 
     def handle_show_season_match(
-        self, season, matched_shows, file, show_data, webhook_run, show_seasons
+        self, season, matched_shows, file, show_data, show_seasons
     ):
         season_has_episodes = season.get("has_episodes", None)
         matched_shows[file] = {
             "has_episodes": season_has_episodes,
             "match": show_data,
         }
-        if webhook_run:
-            matched_shows[file]["webhook_run"] = webhook_run
         # remove to determine later if we have all of the seasons
         show_seasons.remove(season)
 
@@ -377,7 +367,6 @@ class PosterRenamerr:
         file,
         show_status,
         show_has_episodes,
-        webhook_run,
         show_seasons,
         show_data,
     ):
@@ -386,8 +375,6 @@ class PosterRenamerr:
             "has_episodes": show_has_episodes,
             "match": show_data,
         }
-        if webhook_run:
-            matched_shows[file]["webhook_run"] = webhook_run
         show_data["series_poster_matched"] = True
         self.logger.debug(f"Show seasons: {show_seasons}")
 
@@ -411,14 +398,14 @@ class PosterRenamerr:
                 id_match = (
                     asset["media_ids"][id_source] == media["media_ids"][id_source]
                 )
-                self.logger.info(
+                self.logger.debug(
                     f"both sides shared a common id! do they match? {id_match} ... asset_ids= {asset['media_ids']}, media_ids= {media['media_ids']}"
                 )
                 # if the current source existed but didn't match, but there are still other IDs to consider - keep looping
                 if id_match:
                     return True
             # at this point we know there were common sources and if any had matched we would have short circuited above.
-            self.logger.info(
+            self.logger.debug(
                 f"both sides shared a common id! but none matched ... asset_ids= {asset['media_ids']}, media_ids= {media['media_ids']}"
             )
             return False
@@ -895,7 +882,7 @@ class PosterRenamerr:
         return stats
 
     def get_alt_titles_from_media_item(self, media_item):
-        if self.match_alt or media_item.get("webhook_run", None):
+        if self.match_alt:
             alt_titles_clean = [
                 utils.remove_chars(alt)
                 for alt in media_item.get("alternate_titles", [])
@@ -922,7 +909,6 @@ class PosterRenamerr:
         show_status = show_data.get("status", "")
         show_seasons = show_data.get("seasons", [])
         show_has_episodes = show_data.get("has_episodes", None)
-        webhook_run = show_data.get("webhook_run", None)
 
         media_object = {}
         self.compute_variations_for_comparisons(search_title, media_object)
@@ -1003,7 +989,6 @@ class PosterRenamerr:
                                     matched_files["shows"],
                                     file,
                                     show_data,
-                                    webhook_run,
                                     show_seasons,
                                 )
                                 matched_season = True
@@ -1042,7 +1027,6 @@ class PosterRenamerr:
                         file,
                         show_status,
                         show_has_episodes,
-                        webhook_run,
                         show_seasons,
                         show_data,
                     )
@@ -1089,7 +1073,6 @@ class PosterRenamerr:
         movie_years = movie_data.get("years", [])
         movie_status = movie_data.get("status", "")
         movie_has_file = movie_data.get("has_file", None)
-        webhook_run = movie_data.get("webhook_run", None)
 
         media_object = {}
         self.compute_variations_for_comparisons(search_title, media_object)
@@ -1136,7 +1119,6 @@ class PosterRenamerr:
                         movie_data,
                         movie_has_file,
                         movie_status,
-                        webhook_run,
                     )
                     search_match["previously_matched"] = f"movies: {movie_title}"
                     break  # found a match break the search match loop
@@ -1524,13 +1506,15 @@ class PosterRenamerr:
         matched_files: dict[str, dict],
         cb: Callable[[str, int, ProgressState], None] | None = None,
         job_id: str | None = None,
+        webhook_run: bool | None = None,
     ) -> None:
         matched_movies = len(matched_files.get("movies", []))
         matched_shows = len(matched_files.get("shows", []))
         matched_collections = len(matched_files.get("collections", []))
         total_matched_items = matched_movies + matched_shows + matched_collections
         with tqdm(
-            total=total_matched_items, desc="Processing matched files"
+            total=total_matched_items,
+            desc=f"Processing matched files (webhook_run={webhook_run})",
         ) as progress_bar:
             processed_items = 0
             for key, items in matched_files.items():
@@ -1551,7 +1535,7 @@ class PosterRenamerr:
                                 self.replace_border,
                                 status=data.get("status", None),
                                 has_file=data.get("has_file", None),
-                                webhook_run=data.get("webhook_run", None),
+                                webhook_run=webhook_run,
                             )
                         else:
                             self.logger.warning(
@@ -1580,6 +1564,7 @@ class PosterRenamerr:
                                 backup_dir,
                                 file_name_format,
                                 self.replace_border,
+                                webhook_run=webhook_run,
                             )
                         else:
                             self.logger.warning(
@@ -1633,7 +1618,7 @@ class PosterRenamerr:
                                 self.replace_border,
                                 status=data.get("status", None),
                                 has_episodes=data.get("has_episodes", None),
-                                webhook_run=data.get("webhook_run", None),
+                                webhook_run=webhook_run,
                             )
                         else:
                             self.logger.warning(
@@ -1683,8 +1668,6 @@ class PosterRenamerr:
                 return None
 
             for item in items:
-                if upload_to_plex:
-                    item["webhook_run"] = True
                 media_dict["movies" if asset_type == "movie" else "shows"].append(item)
             self.logger.debug(f"Fetched {asset_type}: {items}")
             return media_dict
@@ -1811,6 +1794,7 @@ class PosterRenamerr:
                 matched_files,
                 cb,
                 job_id,
+                webhook_run=bool(single_item),
             )
 
             if self.clean_assets and not single_item:


### PR DESCRIPTION
this isn't needed as the state can be passed through the function calls instead.  This sets up for supporting a collection-based webhook where collections are not objects, too.