### PR TITLE
change duplicate webhook detection to pull season number from metadata

### DIFF
--- a/daps_webui/utils/webhook_manager.py
+++ b/daps_webui/utils/webhook_manager.py
@@ -13,13 +13,7 @@ class WebhookManager:
         self.logger = logger
 
     def is_duplicate_webhook(self, new_item, cache_duration=600) -> bool:
-        if new_item.get("type") == "series":
-            item_path = Path(new_item["item_path"])
-            season = item_path.name
-            series_name = item_path.parent.name
-            item_name = f"{series_name} - {season}"
-        else:
-            item_name = Path(new_item["item_path"]).stem
+        item_name = Path(new_item["item_path"]).stem
 
         now = datetime.now(timezone.utc)
         cutoff = now - timedelta(seconds=cache_duration)

--- a/daps_webui/views/poster_renamer/poster_renamer.py
+++ b/daps_webui/views/poster_renamer/poster_renamer.py
@@ -487,7 +487,24 @@ def recieve_webhook():
         if item_type == "movie":
             item_path = data.get(item_type, {}).get("folderPath", None)
         elif item_type == "series":
-            item_path = data.get("destinationPath", None)
+            item_path = data.get(item_type, {}).get("path", None)
+            episodes = data.get("episodes", [])
+            if episodes:
+                episode = episodes[0]
+                season_number = episode.get("seasonNumber", None)
+                if season_number:
+                    item_path = f"{item_path}-Season{season_number}"
+                    daps_logger.debug(
+                        f"Found episodes, updating item_path to '{item_path}'"
+                    )
+                else:
+                    daps_logger.debug(
+                        f"No season number found, sticking with item_path= '{item_path}'"
+                    )
+            else:
+                daps_logger.debug(
+                    f"No episode info found, sticking with item_path= '{item_path}'"
+                )
 
         if not item_path:
             daps_logger.error("Item path missing from webhook data")


### PR DESCRIPTION
there are certain cases where a destination path will not exist. this will pull the data off of the episide data instead and append to the series path

NOTE: I did not re-test this :-) 