### PR TITLE
if there's no edition, set a default value for upload purposes only

### DIFF
--- a/DapsEX/plex_upload.py
+++ b/DapsEX/plex_upload.py
@@ -65,7 +65,7 @@ class PlexUploaderr:
             for item in plex_media_objects:
                 try:
                     library = getattr(item, "librarySectionTitle", "Unknown Library")
-                    edition = getattr(item, "editionTitle", None)
+                    edition = getattr(item, "editionTitle", "default_no_edition_specified")
                     # this is where we should remove the overlay label in plex that kometa added
                     labels = getattr(item, "labels", None)
                     hasKometaOverlayLabel = False
@@ -235,7 +235,7 @@ class PlexUploaderr:
                 if isinstance(plex_object, list):
                     for item in plex_object:
                         if file_name == item_name:
-                            edition_title = getattr(item, "editionTitle", "")
+                            edition_title = getattr(item, "editionTitle", "default_no_edition_specified")
                             if edition_title:
                                 if edition_title in uploaded_editions:
                                     self.logger.debug(
@@ -257,7 +257,7 @@ class PlexUploaderr:
                             library_has_match = True
                 else:
                     if file_name == item_name:
-                        edition_title = getattr(plex_object, "editionTitle", "")
+                        edition_title = getattr(plex_object, "editionTitle", "default_no_edition_specified")
                         if edition_title:
                             if edition_title in uploaded_editions:
                                 self.logger.debug(

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 zarskie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
this allows something that has an edition to be upgraded (quality score-wise) to a version that doesn't have an edition.  Previously if an edition existed first but then an upgrade did not have an edition the code would just look at the libraries it was added to. now this will also see if an edition is there for the default case.

did not test this, but conceptually this should work.