### PR TITLE
switch away from relying on media paths

### DIFF
--- a/DapsEX/media.py
+++ b/DapsEX/media.py
@@ -31,16 +31,26 @@ class Media:
             }
             series_id = media_object.id
             path = Path(media_object.path)  # type: ignore
-            title = path.name
+            title = media_object.title
+            year = str(media_object.year)
+            tvdb_id = str(media_object.tvdbId)
+            imdb_id = str(media_object.imdbId)
+            tmdb_id = "0"
             series_status = media_object.status
             season_object = media_object.seasons
-            dict_with_seasons["title"] = title
+            dict_with_seasons["arr_title"] = title
             dict_with_seasons["status"] = series_status
             dict_with_seasons["id"] = series_id
-
+            dict_with_seasons["media_year"] = year
+            dict_with_seasons["tvdb_id"] = tvdb_id
+            dict_with_seasons["imdb_id"] = imdb_id
+            dict_with_seasons["path"] = media_object.path
+            dict_with_seasons["folder"] = path.name
             try:
                 raw_api = media_object._raw
                 series_data = raw_api.get_series_id(series_id)
+                tmdb_id = str(series_data.get("tmdbId", 0))
+                dict_with_seasons["tmdb_id"] = tmdb_id
                 if series_data:
                     alternate_titles = self.extract_alternate_titles(
                         series_data.get("alternateTitles", [])
@@ -50,6 +60,13 @@ class Media:
                 logger.error(
                     f"Error fetching series data for ID {series_id}, title={title}: {e}"
                 )
+            dict_with_seasons["title"] = f"{dict_with_seasons['arr_title']} ({dict_with_seasons['media_year']})"
+            if tmdb_id != "0":
+                dict_with_seasons["title"] = f"{dict_with_seasons['title']} {{tmdb-{tmdb_id}}}"
+            if tvdb_id != "0":
+                dict_with_seasons["title"] = f"{dict_with_seasons['title']} {{tvdb-{tvdb_id}}}"
+            if imdb_id != "0":
+                dict_with_seasons["title"] = f"{dict_with_seasons['title']} {{imdb-{imdb_id}}}"
 
             for season in season_object:  # type: ignore
                 season_dict = {
@@ -92,10 +109,12 @@ class Media:
             }
             path = Path(media_object.path)  # type: ignore
             movie_id = media_object.id
-            title = path.name
+            title = media_object.title
             title_year = str(media_object.year)
             status = media_object.status
             has_file = media_object.hasFile
+            imdb_id = str(media_object.imdbId)
+            tmdb_id = str(media_object.tmdbId)
 
             # get raw
             try:
@@ -112,11 +131,20 @@ class Media:
                 logger.error(
                     f"Error fetching movie data for ID {movie_id}, title={title}: {e}"
                 )
-            dict_with_years["title"] = title
+            dict_with_years["arr_title"] = title
             dict_with_years["status"] = status
             dict_with_years["has_file"] = has_file
             dict_with_years["id"] = movie_id
             dict_with_years["media_year"] = title_year
+            dict_with_years["imdb_id"] = imdb_id
+            dict_with_years["tmdb_id"] = tmdb_id
+            dict_with_years["path"] = media_object.path
+            dict_with_years["folder"] = path.name
+            dict_with_years["title"] = f"{dict_with_years['arr_title']} ({dict_with_years['media_year']})"
+            if tmdb_id != "0":
+                dict_with_years["title"] = f"{dict_with_years['title']} {{tmdb-{tmdb_id}}}"
+            if imdb_id != "0":
+                dict_with_years["title"] = f"{dict_with_years['title']} {{imdb-{imdb_id}}}"
 
             titles_with_years.append(dict_with_years)
         return titles_with_years

--- a/DapsEX/poster_renamerr.py
+++ b/DapsEX/poster_renamerr.py
@@ -221,12 +221,12 @@ class PosterRenamerr:
             )
             titles = (
                 set(
-                    utils.remove_chars(movie["title"])
+                    utils.remove_chars(movie["folder"])
                     for movie in media_dict.get("movies", [])
                 )
                 .union(
                     set(
-                        utils.remove_chars(show["title"])
+                        utils.remove_chars(show["folder"])
                         for show in media_dict.get("shows", [])
                     )
                 )
@@ -1522,8 +1522,9 @@ class PosterRenamerr:
                     for file_path, data in items.items():
                         movie_data = data["match"]
                         movie_title = movie_data["title"]
+                        movie_folder = movie_data["folder"]
                         target_dir, backup_dir, file_name_format = self.setup_dirs(
-                            "movie", movie_title, file_path
+                            "movie", movie_folder, file_path
                         )
                         if target_dir and file_name_format:
                             self._copy_file(
@@ -1581,6 +1582,7 @@ class PosterRenamerr:
                     for file_path, data in items.items():
                         show_data = data["match"]
                         show_name = show_data["title"]
+                        show_folder = show_data["folder"]
 
                         match_season = re.match(r"(.+?) - Season (\d+)", file_path.stem)
                         match_specials = re.match(r"(.+?) - Specials", file_path.stem)
@@ -1590,7 +1592,7 @@ class PosterRenamerr:
                             formatted_season_num = f"Season{season_num:02}"
                             target_dir, backup_dir, file_name_format = self.setup_dirs(
                                 "season",
-                                show_name,
+                                show_folder,
                                 file_path,
                                 formatted_season_num,
                                 "_",
@@ -1598,14 +1600,14 @@ class PosterRenamerr:
                         elif match_specials:
                             target_dir, backup_dir, file_name_format = self.setup_dirs(
                                 "special",
-                                show_name,
+                                show_folder,
                                 file_path,
                                 "Season00",
                                 "_",
                             )
                         else:
                             target_dir, backup_dir, file_name_format = self.setup_dirs(
-                                "series", show_name, file_path
+                                "series", show_folder, file_path
                             )
 
                         if target_dir and file_name_format:

--- a/DapsEX/unmatched_assets.py
+++ b/DapsEX/unmatched_assets.py
@@ -122,7 +122,7 @@ class UnmatchedAssets:
         season_assets = self.extract_assets("shows", assets, is_series_asset=True)
 
         for movie in movies_list_dict:
-            if movie["title"].lower() not in movie_assets:
+            if movie["folder"].lower() not in movie_assets:
                 if show_all_unmatched:
                     unmatched_assets["movies"].append(utils.strip_id(movie["title"]))
                     self.db.add_unmatched_movie(
@@ -157,7 +157,7 @@ class UnmatchedAssets:
             }
 
             show_id = None
-            if item["title"].lower() not in show_assets:
+            if item["folder"].lower() not in show_assets:
                 if show_all_unmatched or item.get("has_episodes", False):
                     show_id = self.db.add_unmatched_show(
                         title=show_title,
@@ -170,7 +170,7 @@ class UnmatchedAssets:
                     self.logger.debug(f"Skipping {item['title']} -> No file on disk")
 
             for season in item.get("seasons", []):
-                season_name = item["title"].lower()
+                season_name = item["folder"].lower()
                 season_number = season["season"]
                 season_asset = (season_name, season_number)
 
@@ -179,7 +179,7 @@ class UnmatchedAssets:
                         if show_all_unmatched or season.get("has_episodes", False):
                             unmatched_show["seasons"].append(season["season"])
                             if show_id is None:
-                                series_parent_path = self.assets_dir / item["title"]
+                                series_parent_path = self.assets_dir / item["folder"]
                                 main_series_poster = None
                                 for ext in self.image_exts:
                                     potential_poster = (


### PR DESCRIPTION
instead rely on the metadata coming back from the arrs and only use the folder name to determine the output folder/file name for the asset as that is what Kometa would rely on as well