### PR TITLE
avoid extra calls to arrs for alt titles and a few other fields

### DIFF
--- a/DapsEX/media.py
+++ b/DapsEX/media.py
@@ -16,8 +16,7 @@ from plexapi.server import PlexServer
 
 class Media:
     def get_series_with_seasons(
-        self, logger, all_series_objects: list[Series], instance_name: str,
-        skip_alternate_metadata: bool = False
+        self, logger, all_series_objects: list[Series], instance_name: str
     ):
         titles_with_seasons = []
         for media_object in all_series_objects:
@@ -47,23 +46,15 @@ class Media:
             dict_with_seasons["imdb_id"] = imdb_id
             dict_with_seasons["path"] = media_object.path
             dict_with_seasons["folder"] = path.name
-            if not skip_alternate_metadata:
-                try:
-                    raw_api = media_object._raw
-                    series_data = raw_api.get_series_id(series_id)
-                    tmdb_id = str(series_data.get("tmdbId", 0))
-                    dict_with_seasons["tmdb_id"] = tmdb_id
-                    if series_data:
-                        alternate_titles = self.extract_alternate_titles(
-                            series_data.get("alternateTitles", [])
-                        )
-                        dict_with_seasons["alternate_titles"] = alternate_titles
-                except Exception as e:
-                    logger.error(
-                        f"Error fetching series data for ID {series_id}, title={title}: {e}"
-                    )
-            else:
-                dict_with_seasons["alternate_titles"] = []
+            # ugly to access the protected member, but needed for full data to avoid extra API calls
+            series_data = media_object._data
+            tmdb_id = str(series_data.get("tmdbId", 0))
+            dict_with_seasons["tmdb_id"] = tmdb_id
+            if series_data:
+                alternate_titles = self.extract_alternate_titles(
+                    series_data.get("alternateTitles", [])
+                )
+                dict_with_seasons["alternate_titles"] = alternate_titles
             dict_with_seasons["title"] = f"{dict_with_seasons['arr_title']} ({dict_with_seasons['media_year']})"
             if tmdb_id != "0":
                 dict_with_seasons["title"] = f"{dict_with_seasons['title']} {{tmdb-{tmdb_id}}}"
@@ -96,12 +87,9 @@ class Media:
         return titles_with_seasons
 
     def get_movies_with_years(
-        self, all_movie_objects: list[Movie], instance_name: str, logger,
-        skip_alternate_metadata: bool = False
-
+        self, all_movie_objects: list[Movie], instance_name: str, logger
     ) -> list[dict[str, str | list[str]]]:
         titles_with_years = []
-
         for media_object in all_movie_objects:
             dict_with_years = {
                 "title": "",
@@ -121,24 +109,15 @@ class Media:
             has_file = media_object.hasFile
             imdb_id = str(media_object.imdbId)
             tmdb_id = str(media_object.tmdbId)
-
-            if not skip_alternate_metadata:
-                try:
-                    raw_api = media_object._raw
-                    movie_data = raw_api.get_movie_id(movie_id)
-                    alternate_titles = self.extract_movie_alternate_titles(
-                        movie_data.get("alternateTitles", [])
-                    )
-                    dict_with_years["alternate_titles"] = alternate_titles
-                    secondary_year = movie_data.get("secondaryYear", None)
-                    if secondary_year:
-                        dict_with_years["years"].append(str(secondary_year))
-                except Exception as e:
-                    logger.error(
-                        f"Error fetching movie data for ID {movie_id}, title={title}: {e}"
-                    )
-            else:
-                dict_with_years["alternate_titles"] = []
+            # ugly to access the protected member, but needed for full data to avoid extra API calls
+            movie_data = media_object._data
+            alternate_titles = self.extract_movie_alternate_titles(
+                movie_data.get("alternateTitles", [])
+            )
+            dict_with_years["alternate_titles"] = alternate_titles
+            secondary_year = movie_data.get("secondaryYear", None)
+            if secondary_year:
+                dict_with_years["years"].append(str(secondary_year))
             dict_with_years["arr_title"] = title
             dict_with_years["status"] = status
             dict_with_years["has_file"] = has_file
@@ -193,13 +172,12 @@ class Radarr(Media):
             raise e
 
     # memoize this
-    def get_movies_info(self, skip_alternate_metadata: bool = False):
+    def get_movies_info(self):
         if not self.movies:
             self.movies = self.get_movies_with_years(
                 self.all_movie_objects,
                 self.instance_name,
-                self.logger,
-                skip_alternate_metadata,
+                self.logger
             )
         return self.movies
 
@@ -234,13 +212,12 @@ class Sonarr(Media):
             raise e
 
     # memoize this
-    def get_series_info(self, skip_alternate_metadata: bool = False):
+    def get_series_info(self):
         if not self.series:
             self.series = self.get_series_with_seasons(
                 self.logger,
                 self.all_series_objects,
-                self.instance_name,
-                skip_alternate_metadata
+                self.instance_name
             )
         return self.series
 

--- a/DapsEX/plex_upload.py
+++ b/DapsEX/plex_upload.py
@@ -664,7 +664,7 @@ class PlexUploaderr:
 
     def update_cached_files(self, cached_files: dict):
         media_dict = utils.get_combined_media_dict(
-            self.radarr_instances, self.sonarr_instances, skip_alternate_metadata=True
+            self.radarr_instances, self.sonarr_instances, self.logger
         )
         movies_lookup = {
             movie["folder"].lower(): movie["has_file"]

--- a/DapsEX/poster_renamerr.py
+++ b/DapsEX/poster_renamerr.py
@@ -1793,7 +1793,7 @@ class PosterRenamerr:
                     )
 
                 media_dict = utils.get_combined_media_dict(
-                    self.radarr_instances, self.sonarr_instances
+                    self.radarr_instances, self.sonarr_instances, self.logger
                 )
                 collections_dict = utils.get_combined_collections_dict(
                     self.plex_instances

--- a/DapsEX/unmatched_assets.py
+++ b/DapsEX/unmatched_assets.py
@@ -511,7 +511,7 @@ class UnmatchedAssets:
 
             self.logger.debug("Creating media and collections dict.")
             media_dict = utils.get_combined_media_dict(
-                self.radarr_instances, self.sonarr_instances, skip_alternate_metadata=True
+                self.radarr_instances, self.sonarr_instances, self.logger
             )
             collections_dict = utils.get_combined_collections_dict(self.plex_instances)
             if job_id and cb:

--- a/DapsEX/utils.py
+++ b/DapsEX/utils.py
@@ -12,12 +12,12 @@ from Payloads.unmatched_assets_payload import Payload as UnmatchedAssetsPayload
 
 def get_combined_media_dict(
     radarr_instances: dict[str, Radarr], sonarr_instances: dict[str, Sonarr],
-    skip_alternate_metadata: bool = False
+    logger: Logger
 ) -> dict:
     combined_series_dict = {}
     combined_movies_dict = {}
     for radarr in radarr_instances.values():
-        for movie in radarr.get_movies_info(skip_alternate_metadata): # need to determine if we should skip other metadata here
+        for movie in radarr.get_movies_info():
             movie_title = movie["title"]
             if movie_title not in combined_movies_dict:
                 combined_movies_dict[movie_title] = movie
@@ -28,7 +28,7 @@ def get_combined_media_dict(
                 ):
                     existing_movie["has_file"] = True
     for sonarr in sonarr_instances.values():
-        for series in sonarr.get_series_info(skip_alternate_metadata): # need to determine if we should skip other metadata here
+        for series in sonarr.get_series_info():
             series_title = series["title"]
             if series_title not in combined_series_dict:
                 combined_series_dict[series_title] = series


### PR DESCRIPTION
this data is present in the "list all [movies|shows]" API, but the API package doesn't support accessing it.  Previously this would lead to more calls to the arrs for _each item_ to fetch this using the _raw API, but that's not necessary and can be avoided simply by accessing the underlying json response from the "list all" APIs.  Unfortunately this has to be done via a protected attribute but the alternative would be to move away from the API package entirely for now, so this should be OK given the state of the projects.