### PR TITLE
Reset poster search cache on drive sync completion and add manual reset to poster search

### DIFF
--- a/frontend/src/components/dashboard/PosterSearch.jsx
+++ b/frontend/src/components/dashboard/PosterSearch.jsx
@@ -6,6 +6,7 @@ import { CircleQuestionMark } from "lucide-react";
 function PosterSearch() {
   const tooltipTimeout = useRef(null);
   const [activeTooltip, setActiveTooltip] = useState(null);
+  const [status, setStatus] = useState(null);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState([]);
   const [total, setTotal] = useState(0);
@@ -30,6 +31,13 @@ function PosterSearch() {
 
   const cancelHide = () => {
     clearTimeout(tooltipTimeout.current);
+  };
+
+  const handleResetCache = async () => {
+    setStatus("loading");
+    await fetch("/api/poster-search/reset-cache", { method: "PUT" });
+    setStatus("done");
+    setTimeout(() => setStatus(null), 2000);
   };
 
   useEffect(() => {
@@ -205,6 +213,17 @@ function PosterSearch() {
               )}
             </div>
           </div>
+          <button
+            disabled={status === "loading"}
+            className={`ml-auto w-24 rounded-full border px-2 py-0.5 text-xs text-white transition-colors duration-300 disabled:opacity-50 ${status === "done" ? "border-green-700 bg-green-600" : "border-blue-700 bg-blue-600 hover:bg-blue-700"}`}
+            onClick={handleResetCache}
+          >
+            {status === "loading"
+              ? "resetting..."
+              : status === "done"
+                ? "✓ done"
+                : "reset cache"}
+          </button>
         </div>
       </div>
       {loading && <p className="mt-1 text-xs text-gray-500">Searching...</p>}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1240,6 +1240,10 @@ function Settings() {
                           </span>
                         )}
                     </div>
+                    <span className="text-xs text-gray-400">
+                      Must match: *arr &rarr; General &rarr; Advanced &rarr;
+                      Instance Name
+                    </span>
                   </div>
                 </div>
               </div>

--- a/postarr/__init__.py
+++ b/postarr/__init__.py
@@ -672,6 +672,8 @@ def run_plex_uploaderr_task(app, overrides: dict | None = None):
 def run_drive_sync_task(
     app, overrides: dict | None = None, chained: bool = False
 ) -> dict:
+    from postarr.views.poster_search.poster_search import reset_cache
+
     with app.app_context():
         postarr_logger.info(f"run_drive_sync_task called with chained={chained}")
         payload = webui_utils.create_drive_sync_payload()
@@ -693,6 +695,7 @@ def run_drive_sync_task(
             except Exception as e:
                 postarr_logger.debug(f"Error removing job '{job_id}': {e}")
             finally:
+                reset_cache()
                 sleep(2)
                 progress_instance.remove_job(job_id)
                 postarr_logger.info(f"Drive Sync: '{job_id}' has been removed")
@@ -700,6 +703,7 @@ def run_drive_sync_task(
         if chained:
             try:
                 drive_sync.sync_all_drives(progress_instance, job_id)
+                reset_cache()
                 progress_instance.remove_job(job_id)
                 postarr_logger.info(f"Drive Sync: '{job_id}' has been removed")
             except Exception as e:

--- a/postarr/views/poster_search/poster_search.py
+++ b/postarr/views/poster_search/poster_search.py
@@ -25,6 +25,13 @@ def build_cache(root_dir):
     ]
 
 
+def reset_cache():
+    global _file_cache, _cache_built
+    _file_cache = []
+    _cache_built = False
+    postarr_logger.info("Poster search cache reset")
+
+
 def get_cache():
     global _file_cache, _cache_built
     if not _cache_built:
@@ -89,3 +96,9 @@ def serve_poster_image():
         return send_from_directory(directory, filename)
     except Exception as e:
         return jsonify({"success": False, "message": str(e)}), 500
+
+
+@poster_search.route("/reset-cache", methods=["PUT"])
+def reset_cache_manual():
+    reset_cache()
+    return jsonify({"success": True, "message": "Cache reset successfully"})


### PR DESCRIPTION
Call reset cache after drive sync run completes and also added a way to manually reset the cache from the UI. Also added important info under instance name when adding/editing instances.